### PR TITLE
Fixed bug where the upper body item (and lower body item) doesn't always save

### DIFF
--- a/Assets/Resources/OutfitSaveResource.tres
+++ b/Assets/Resources/OutfitSaveResource.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="OutfitSaveResource" load_steps=2 format=3 uid="uid://bpj7xp4auijj6"]
 
-[ext_resource type="Script" uid="uid://dakm6oj3wnsac" path="res://Scripts/OutfitSaveResource.gd" id="1_38rcr"]
+[ext_resource type="Script" path="res://Scripts/OutfitSaveResource.gd" id="1_38rcr"]
 
 [resource]
 script = ExtResource("1_38rcr")

--- a/Assets/Resources/Wearables/greenShirtS.tres
+++ b/Assets/Resources/Wearables/greenShirtS.tres
@@ -1,22 +1,22 @@
 [gd_resource type="Resource" script_class="Wearable" load_steps=18 format=3 uid="uid://du7yuwoc6pm30"]
 
-[ext_resource type="Texture2D" uid="uid://cp0h2c2r74y14" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Pose28/Pose28LongSleeves2.png" id="1_oydov"]
-[ext_resource type="Texture2D" uid="uid://wfprhjluofer" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Pose28/Pose28LongSleeves1.png" id="2_wo5ju"]
-[ext_resource type="Texture2D" uid="uid://dhvjdnoflaakm" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Idle Frames/IdleLongSleeve0.png" id="3_qa518"]
-[ext_resource type="Texture2D" uid="uid://dwxaiy6noqu1q" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Idle Frames/IdleLongSleeve1.png" id="4_wndmk"]
-[ext_resource type="Texture2D" uid="uid://dbf76elru6rnq" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Kick Frames/KickLongSleeve1.png" id="5_yu8id"]
-[ext_resource type="Texture2D" uid="uid://pbxx8w5v3fxw" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Kick Frames/KickLongSleeve2.png" id="6_ey0i5"]
-[ext_resource type="Texture2D" uid="uid://ialgbdgj5hw0" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Mirror Frames/FinalizedModelLongSleeve.png" id="7_emh0l"]
-[ext_resource type="Texture2D" uid="uid://c7bkdq5ca3ge4" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Knockout Frames/KnockOutLongSleeve1.png" id="7_wndmk"]
-[ext_resource type="Texture2D" uid="uid://dckp4bghy70ml" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Punch Frames/PunchLongSleeve1.png" id="8_wmdsu"]
-[ext_resource type="Texture2D" uid="uid://dcswdlo8yoyya" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Knockout Frames/KnockOutLongSleeve2.png" id="8_yu8id"]
-[ext_resource type="Texture2D" uid="uid://da01phg6yscv3" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Knockout Frames/KnockOutLongSleeve3.png" id="9_ey0i5"]
-[ext_resource type="Texture2D" uid="uid://c3u13hdtq8nft" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Punch Frames/PunchLongSleeve2.png" id="9_luspp"]
+[ext_resource type="Texture2D" uid="uid://c86ote5ny0tqv" path="res://Assets/Sprites/Clothing Frames/TankTop/Pose 28/Pose28TankTop2.png" id="1_wndmk"]
+[ext_resource type="Texture2D" uid="uid://blp37uqgtutyg" path="res://Assets/Sprites/Clothing Frames/TankTop/Pose 28/Pose28TankTop1.png" id="2_yu8id"]
+[ext_resource type="Texture2D" uid="uid://befe1kgue6m5d" path="res://Assets/Sprites/Clothing Frames/TankTop/Idle Frames/IdleTankTop0.png" id="3_ey0i5"]
+[ext_resource type="Texture2D" uid="uid://c8dedxku14gmt" path="res://Assets/Sprites/Clothing Frames/TankTop/Idle Frames/IdleTankTop1.png" id="4_emh0l"]
+[ext_resource type="Texture2D" uid="uid://cxv8l604cup7c" path="res://Assets/Sprites/Clothing Frames/TankTop/Kick Frames/KickTankTop1.png" id="5_wmdsu"]
+[ext_resource type="Texture2D" uid="uid://c6fm3kr4h78pm" path="res://Assets/Sprites/Clothing Frames/TankTop/Kick Frames/KickTankTop2.png" id="6_luspp"]
+[ext_resource type="Texture2D" uid="uid://bsjp5rhd4npan" path="res://Assets/Sprites/Clothing Frames/TankTop/Knockout Frames/KnockOutTankTop1.png" id="7_bpkwn"]
+[ext_resource type="Texture2D" uid="uid://d0siyhgd7uaeq" path="res://Assets/Sprites/Clothing Frames/TankTop/Knockout Frames/KnockOutTankTop2.png" id="8_nps1d"]
+[ext_resource type="Texture2D" uid="uid://biojj1ixsrl3q" path="res://Assets/Sprites/Clothing Frames/TankTop/Knockout Frames/KnockOutTankTop3.png" id="9_hi3nr"]
 [ext_resource type="Script" uid="uid://0bwef23hrt6j" path="res://Scripts/Wearable.gd" id="10_bpkwn"]
-[ext_resource type="Texture2D" uid="uid://bksjgxh1fyag4" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Walk Frames/WalkLongSleeve0.png" id="11_nps1d"]
-[ext_resource type="Texture2D" uid="uid://bqej65d8gmo3w" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Walk Frames/WalkLongSleeve1.png" id="12_hi3nr"]
-[ext_resource type="Texture2D" uid="uid://ddvg7100aqrlw" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Walk Frames/WalkLongSleeve2.png" id="13_ea80w"]
-[ext_resource type="Texture2D" uid="uid://di68p6046j5h" path="res://Assets/Sprites/Clothing Frames/LongSleeve/Walk Frames/WalkLongSleeve3.png" id="14_tjfxh"]
+[ext_resource type="Texture2D" uid="uid://5by10m7sf0jw" path="res://Assets/Sprites/Clothing Frames/TankTop/Mirror Frames/FinalizedModelTankTop.png" id="10_ea80w"]
+[ext_resource type="Texture2D" uid="uid://bcmoamei1rl4v" path="res://Assets/Sprites/Clothing Frames/TankTop/Punch Frames/PunchTankTop1.png" id="11_tjfxh"]
+[ext_resource type="Texture2D" uid="uid://ddcp6eyf42nte" path="res://Assets/Sprites/Clothing Frames/TankTop/Punch Frames/PunchTankTop2.png" id="12_hh8u1"]
+[ext_resource type="Texture2D" uid="uid://cucscdajnr4nq" path="res://Assets/Sprites/Clothing Frames/TankTop/Walk Frames/WalkTankTop0.png" id="14_b3p2p"]
+[ext_resource type="Texture2D" uid="uid://dxepgjv0aomr1" path="res://Assets/Sprites/Clothing Frames/TankTop/Walk Frames/WalkTankTop1.png" id="15_fa8y3"]
+[ext_resource type="Texture2D" uid="uid://d2b4exycwbjvf" path="res://Assets/Sprites/Clothing Frames/TankTop/Walk Frames/WalkTankTop2.png" id="16_w6kit"]
+[ext_resource type="Texture2D" uid="uid://veq4symhd1wh" path="res://Assets/Sprites/Clothing Frames/TankTop/Walk Frames/WalkTankTop3.png" id="17_mwkpn"]
 
 [resource]
 script = ExtResource("10_bpkwn")
@@ -42,20 +42,20 @@ poseHitstunChange = 0.0
 poseKnockbackChange = 0.0
 poseDamageChange = 0.0
 healthChange = 0.25
-mirrorPose = ExtResource("7_emh0l")
-idlePose0 = ExtResource("3_qa518")
-idlePose1 = ExtResource("4_wndmk")
-walkPose0 = ExtResource("11_nps1d")
-walkPose1 = ExtResource("12_hi3nr")
-walkPose2 = ExtResource("13_ea80w")
-walkPose3 = ExtResource("14_tjfxh")
-kickPose0 = ExtResource("5_yu8id")
-kickPose1 = ExtResource("6_ey0i5")
-punchPose0 = ExtResource("8_wmdsu")
-punchPose1 = ExtResource("9_luspp")
-hurtPose = ExtResource("2_wo5ju")
-Pose28 = ExtResource("1_oydov")
-knockOut_pose0 = ExtResource("7_wndmk")
-knockOut_pose1 = ExtResource("8_yu8id")
-knockOut_pose2 = ExtResource("9_ey0i5")
+mirrorPose = ExtResource("10_ea80w")
+idlePose0 = ExtResource("3_ey0i5")
+idlePose1 = ExtResource("4_emh0l")
+walkPose0 = ExtResource("14_b3p2p")
+walkPose1 = ExtResource("15_fa8y3")
+walkPose2 = ExtResource("16_w6kit")
+walkPose3 = ExtResource("17_mwkpn")
+kickPose0 = ExtResource("5_wmdsu")
+kickPose1 = ExtResource("6_luspp")
+punchPose0 = ExtResource("11_tjfxh")
+punchPose1 = ExtResource("12_hh8u1")
+hurtPose = ExtResource("2_yu8id")
+Pose28 = ExtResource("1_wndmk")
+knockOut_pose0 = ExtResource("7_bpkwn")
+knockOut_pose1 = ExtResource("8_nps1d")
+knockOut_pose2 = ExtResource("9_hi3nr")
 metadata/_custom_type_script = "uid://0bwef23hrt6j"

--- a/Scenes/dressup_timer.gd
+++ b/Scenes/dressup_timer.gd
@@ -28,22 +28,24 @@ func _ready() -> void:
 	#$Timer.paused = true;
 	visible = false;
 
-func _process(delta: float) -> void:
-	
-	$RichTextLabel.text = str($Timer.time_left).pad_decimals(2)
-	
-	if(str($Timer.time_left).pad_decimals(2) == "9.50"):
-		var tween = get_tree().create_tween()
-		speech_text.visible = true;
-		tween.tween_property(speech_text, "scale", Vector2(1.1,1.1), .1)
-		tween.tween_property(speech_text, "scale", Vector2(1,1), .1)
-	if(str($Timer.time_left).pad_decimals(2) == "7.50"):
-		speech_text.visible = false;
+# No longer used because the timer is turned off
+#func _process(delta: float) -> void:
+	#
+	#$RichTextLabel.text = str($Timer.time_left).pad_decimals(2)
+	#
+	#if(str($Timer.time_left).pad_decimals(2) == "9.50"):
+		#var tween = get_tree().create_tween()
+		#speech_text.visible = true;
+		#tween.tween_property(speech_text, "scale", Vector2(1.1,1.1), .1)
+		#tween.tween_property(speech_text, "scale", Vector2(1,1), .1)
+	#if(str($Timer.time_left).pad_decimals(2) == "7.50"):
+		#speech_text.visible = false;
 	
 
 func _on_timer_timeout() -> void:
 	#results is the array of clothing items that are one the player
 	var results = get_last_outfit();
+	print(results)
 	
 	#for key in results:
 		#print(key.collider.get_parent().name)
@@ -55,10 +57,14 @@ func _on_timer_timeout() -> void:
 	if results.size() == 2:
 		#if  there is only one, save one that was  added, then the other is default
 		var clothing_name = results[1].collider.get_parent().current_wearable.get_outfit_name()
+		print("T1: " + clothing_name)
+		
 		if (clothing_name.contains("Shirt")):
 			shirt_text = clothing_name
-		elif (clothing_name.contains("Pants")):
+			print("T1.5: " + shirt_text)
+		elif (clothing_name.contains("Pants") || clothing_name.contains("Shorts")):
 			pants_text = clothing_name
+			print("T2: " + pants_text)
 		
 	if results.size() >= 3:
 		#this  makes sure were only getting one shirt and one pants if  there is more than one 
@@ -66,6 +72,7 @@ func _on_timer_timeout() -> void:
 			var current_clothing = results[i].collider.get_parent().current_wearable.get_outfit_name()
 			if(current_clothing.contains("Shirt")):
 				shirt_text = current_clothing
+				print("T3: " + shirt_text)
 			else:
 				pants_text = current_clothing
 			

--- a/Scenes/dressup_timer.gd
+++ b/Scenes/dressup_timer.gd
@@ -98,7 +98,8 @@ func get_last_outfit() -> Array[Dictionary]:
 	query.position = $"../Platform".position
 	query.collide_with_bodies = true  # Adjust as needed
 	query.collide_with_areas = true
-		
+	
+	# This assumes that all collision boxes of each clothing item are touching the intersect point (center of platform box)
 	var results = space_state.intersect_point(query)
 	
 	return results

--- a/Scenes/dressup_timer.gd
+++ b/Scenes/dressup_timer.gd
@@ -57,14 +57,14 @@ func _on_timer_timeout() -> void:
 	if results.size() == 2:
 		#if  there is only one, save one that was  added, then the other is default
 		var clothing_name = results[1].collider.get_parent().current_wearable.get_outfit_name()
-		print("T1: " + clothing_name)
+		# DEBUG: print("T1: " + clothing_name)
 		
 		if (clothing_name.contains("Shirt")):
 			shirt_text = clothing_name
-			print("T1.5: " + shirt_text)
+			# DEBUG: print("T1.5: " + shirt_text)
 		elif (clothing_name.contains("Pants") || clothing_name.contains("Shorts")):
 			pants_text = clothing_name
-			print("T2: " + pants_text)
+			# DEBUG: print("T2: " + pants_text)
 		
 	if results.size() >= 3:
 		#this  makes sure were only getting one shirt and one pants if  there is more than one 
@@ -72,7 +72,7 @@ func _on_timer_timeout() -> void:
 			var current_clothing = results[i].collider.get_parent().current_wearable.get_outfit_name()
 			if(current_clothing.contains("Shirt")):
 				shirt_text = current_clothing
-				print("T3: " + shirt_text)
+				# DEBUG: print("T3: " + shirt_text)
 			else:
 				pants_text = current_clothing
 			
@@ -93,15 +93,40 @@ func _on_timer_timeout() -> void:
 #returns array  of clothingn items that are currently overlapping the platform
 func get_last_outfit() -> Array[Dictionary]:
 	var space_state = get_world_2d().direct_space_state
-		
-	var query = PhysicsPointQueryParameters2D.new()
-	query.position = $"../Platform".position
-	query.collide_with_bodies = true  # Adjust as needed
-	query.collide_with_areas = true
 	
-	# This assumes that all collision boxes of each clothing item are touching the intersect point (center of platform box)
-	var results = space_state.intersect_point(query)
+	# Creates 2 points for the area where the top and bottom items should be
+	var topItemQuery = PhysicsPointQueryParameters2D.new()
+	var bottomItemQuery = PhysicsPointQueryParameters2D.new()
 	
+	# Since the y position for the platform is -21, We want the y to be -90 to match where the upper torso is
+	topItemQuery.position = $"../Platform".position + Vector2(0,-69)
+	topItemQuery.collide_with_bodies = true  # Adjust as needed
+	topItemQuery.collide_with_areas = true
+	
+	# No need to adjust position, position of the platform is already at waist level
+	bottomItemQuery.position = $"../Platform".position
+	bottomItemQuery.collide_with_bodies = true  # Adjust as needed
+	bottomItemQuery.collide_with_areas = true
+	
+	# Puts all objects colliding with the intersection points into a single list
+	var topResults = space_state.intersect_point(topItemQuery)
+	var bottomResults = space_state.intersect_point(bottomItemQuery)
+
+	var results: Array[Dictionary] = []
+	var resultsTemp = []
+	resultsTemp.append_array(topResults)
+	resultsTemp.append_array(bottomResults)
+	
+	# Checks for any duplicates in resultsTemp, if it's not a duplicate, append it to results list
+	var seen_ids = {}
+	for collision in resultsTemp:
+		if "collider" in collision:
+			var collider_id = collision["collider"].get_instance_id()
+			if not seen_ids.has(collider_id):
+				seen_ids[collider_id] = true
+				results.append(collision)
+	
+	# Note: return bottomResults instead if you want to go back to the old system.
 	return results
 
 

--- a/Scenes/object.gd
+++ b/Scenes/object.gd
@@ -80,7 +80,7 @@ func set_random_shirt_wearable():
 		$Area2D/CollisionShape2D.position.y = -31 # original = -31
 	if current_wearable.name[length_of_name-1] == "S": #ShirtS
 		# Currently a band-aid fix, if I can find where to adjust the detection range of the collision, I'll set these values back to their originals
-		$Area2D/CollisionShape2D.scale.y = 0.4 # original = 0.2
+		$Area2D/CollisionShape2D.scale.y = 0.2 # original = 0.2
 		$Area2D/CollisionShape2D.position.y = -65 # original = -65
 	
 #when mouse hovers oveer the clothing 	

--- a/Scenes/object.gd
+++ b/Scenes/object.gd
@@ -62,10 +62,10 @@ func set_random_shirt_wearable():
 	
 	#picks a random number
 	var rand = rng.randi_range(0,shirts.size()-1)
+	#rand = 9
 	
 	#generates random shirt
 	current_wearable = load(path + shirts[rand] + ".tres")
-	
 	
 	#Prevents the nerfing gray shirt from spawning by rerolling again if it spawns. If it still happens to spawn after this...I tried.
 	if current_wearable.name == "grayShirtS":
@@ -73,14 +73,15 @@ func set_random_shirt_wearable():
 		current_wearable = load(path + shirts[rand] + ".tres")
 	
 	#brute force way of adusting colission box to be accurate
+	# Made collision boxes for shirts less accurate but equalizied, should fix Clothing Saving Bug
 	var length_of_name = current_wearable.name.length()
 	if current_wearable.name[length_of_name-1] == "L": #ShirtL
-		$Area2D/CollisionShape2D.scale.y = 0.450
-		
-		$Area2D/CollisionShape2D.position.y = -31
+		$Area2D/CollisionShape2D.scale.y = 0.4
+		$Area2D/CollisionShape2D.position.y = -31 # original = -31
 	if current_wearable.name[length_of_name-1] == "S": #ShirtS
-		$Area2D/CollisionShape2D.scale.y = 0.2
-		$Area2D/CollisionShape2D.position.y = -65
+		# Currently a band-aid fix, if I can find where to adjust the detection range of the collision, I'll set these values back to their originals
+		$Area2D/CollisionShape2D.scale.y = 0.4 # original = 0.2
+		$Area2D/CollisionShape2D.position.y = -65 # original = -65
 	
 #when mouse hovers oveer the clothing 	
 func _on_area_2d_mouse_entered():


### PR DESCRIPTION
Main issue was with how collision was handled, where a intersection point was created that assumed all objects within the platform box were touching it; this was not the case for tanktops (ShirtS).

Made a solution with 2 intersection points instead, one where the upper body item should be and another where the lower body item should be, then I added all the colliding objects with said points into one big list.

There was also a check that did not include items with names that contained "Shorts", which made it so wearing shorts wouldn't save at all; this was fixed.

tldr; clothing collision problem is fixed